### PR TITLE
add params dictionary to Request

### DIFF
--- a/src/Meddle.jl
+++ b/src/Meddle.jl
@@ -47,7 +47,7 @@ export Midware,
 
 immutable MeddleRequest
     http_req::Request
-    state::Dict,
+    state::Dict
     params::Dict
 end
 


### PR DESCRIPTION
attempting to make it easier to consume params declared on the route. i.e.

``` julia
get(app, "/hello/<id::Int>") do req, res
  id = req.params[:id]
  "Hello $id"
end
```
